### PR TITLE
[feat] 소비기록 조회 (달력뷰, 리스트뷰) & 무지출에 대한 데이터 null 처리

### DIFF
--- a/src/main/java/donmani/donmani_server/expense/controller/ExpenseController.java
+++ b/src/main/java/donmani/donmani_server/expense/controller/ExpenseController.java
@@ -20,12 +20,21 @@ import lombok.RequiredArgsConstructor;
 public class ExpenseController {
 	private final ExpenseService expenseService;
 
-	@GetMapping("/{userKey}")
-	public ResponseEntity<ExpenseResponseDTO> getExpenses(
+	@GetMapping("/calendar/{userKey}")
+	public ResponseEntity<ExpenseResponseDTO> getExpensesCalendar(
 		@PathVariable String userKey,
 		@RequestParam int year,
 		@RequestParam int month) {
-		ExpenseResponseDTO response = expenseService.getExpenses(userKey, year, month);
+		ExpenseResponseDTO response = expenseService.getExpenses(userKey, year, month, false);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/list/{userKey}")
+	public ResponseEntity<ExpenseResponseDTO> getExpensesList(
+			@PathVariable String userKey,
+			@RequestParam int year,
+			@RequestParam int month) {
+		ExpenseResponseDTO response = expenseService.getExpenses(userKey, year, month, true);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/donmani/donmani_server/expense/dto/RecordDTO.java
+++ b/src/main/java/donmani/donmani_server/expense/dto/RecordDTO.java
@@ -16,8 +16,16 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL) // null 값 제외
 public class RecordDTO {
 	private LocalDate date;
 	private List<ContentDTO> contents; // null 가능
+
+	public static RecordDTO of(LocalDate localDate, List<ContentDTO> contents) {
+		RecordDTO recordDTO = new RecordDTO();
+
+		recordDTO.setDate(localDate);
+		recordDTO.setContents(contents.get(0) == null ? null : contents);
+
+		return recordDTO;
+	}
 }

--- a/src/main/java/donmani/donmani_server/expense/repository/ExpenseRepository.java
+++ b/src/main/java/donmani/donmani_server/expense/repository/ExpenseRepository.java
@@ -3,6 +3,8 @@ package donmani.donmani_server.expense.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +13,13 @@ import donmani.donmani_server.expense.entity.Expense;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	List<Expense> findByUserId(Long userId);
+
 	@Query("SELECT e FROM Expense e WHERE e.userId = :userId AND YEAR(e.createdAt) = :year AND MONTH(e.createdAt) = :month")
 	List<Expense> findByUserIdAndMonth(@Param("userId") Long userId, @Param("year") int year, @Param("month") int month);
 
+	@Query("SELECT DISTINCT e.createdAt FROM Expense e WHERE e.userId = :userId ORDER BY e.createdAt DESC")
+	Page<LocalDateTime> findDistinctCreatedAt(@Param("userId") Long userId, Pageable pageable);
+
+	@Query("SELECT e FROM Expense e WHERE e.createdAt IN :localDateTimes ORDER BY e.createdAt DESC")
+	List<Expense> findByCreatedAtIn(@Param("userId") Long userId, List<LocalDateTime> localDateTimes);
 }


### PR DESCRIPTION
## #20 20

## 📝작업 내용
- 사용자 최신순 페이지네이션 (미사용)
- 무지출에 대한 response 수정 `contents : null`
- 리스트, 캘린더 뷰에 따른 API 구체화

## 💬리뷰 요구사항(선택)

> 예외 캐치 못한 부분 봐주세용. 