### PR TITLE
[hotfix] 무지출 데이터 예외처리

### DIFF
--- a/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
+++ b/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
@@ -12,7 +12,6 @@ import donmani.donmani_server.expense.entity.CategoryType;
 import donmani.donmani_server.expense.entity.FlagType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -215,7 +214,13 @@ public class ExpenseService {
 		Map<CategoryType, Integer> categoryCounts = Arrays.stream(CategoryType.values())
 				.collect(Collectors.toMap(category -> category, category -> 0));
 
-		expenses.forEach(expense -> categoryCounts.put(expense.getCategory(), categoryCounts.get(expense.getCategory()) + 1));
+		expenses.forEach(expense -> {
+			if (expense.getCategory() != null) {
+				categoryCounts.put(
+						expense.getCategory(), categoryCounts.get(expense.getCategory()) + 1);
+			}
+		});
+
 
 		return CategoryStatisticsDTO.builder()
 				.year(year)


### PR DESCRIPTION
## #42

## 📝작업 내용

> 카테고리별 개수를 집계하는 API 엔드포인트에서 `500` 에러 발생
- 사유 : expense의 category가 null인 경우(무지출)에 대하여 예외 처리 부재.
- 해결 : 분기 추가하여 category가 not null 일 때만 category 개수 집계