### PR TITLE
[feat] FCM 메시지 푸시 기능 수정 (key 변경)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Add FCM service account JSON key
         run: |
           cd ./src/main/resources
-          touch ./donmani-5d3f6-firebase-adminsdk-fbsvc-22a01911fd.json
-          echo "${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}" > ./donmani-5d3f6-firebase-adminsdk-fbsvc-22a01911fd.json
+          touch ./bbsofficial-firebase-adminsdk.json
+          echo "${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}" > ./bbsofficial-firebase-adminsdk.json
 
       #test를 제외한 프로젝트 빌드
       - name: Build With Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/donmani/donmani_server/common/config/FirebaseConfig.java
+++ b/src/main/java/donmani/donmani_server/common/config/FirebaseConfig.java
@@ -14,7 +14,7 @@ public class FirebaseConfig {
     @PostConstruct
     public void init() {
         try {
-            InputStream serviceAccount = new ClassPathResource("donmani-5d3f6-firebase-adminsdk-fbsvc-22a01911fd.json").getInputStream();
+            InputStream serviceAccount = new ClassPathResource("bbsofficial-firebase-adminsdk.json").getInputStream();
             FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();

--- a/src/main/java/donmani/donmani_server/fcm/contorller/FCMController.java
+++ b/src/main/java/donmani/donmani_server/fcm/contorller/FCMController.java
@@ -18,4 +18,10 @@ public class FCMController {
         fcmService.saveOrUpdateToken(userKey, token);
         return ResponseEntity.ok("SUCCESS"); // TODO : 응답 포맷팅 작업에서 수정 필요
     }
+
+    @PostMapping("/send-messages/{userKey}")
+    public ResponseEntity<String> saveOrUpdateToken(@PathVariable String userKey) {
+        fcmService.sendMessageTest(userKey);
+        return ResponseEntity.ok("SUCCESS"); // TODO : 응답 포맷팅 작업에서 수정 필요
+    }
 }

--- a/src/main/java/donmani/donmani_server/fcm/service/FCMService.java
+++ b/src/main/java/donmani/donmani_server/fcm/service/FCMService.java
@@ -52,7 +52,7 @@ public class FCMService {
                         .setBody(body)
                         .build())
                 .build();
-
+        System.out.println();
         try {
             FirebaseMessaging.getInstance().send(message);
         } catch (FirebaseMessagingException e) {
@@ -60,6 +60,14 @@ public class FCMService {
         }
     }
 
+    public void sendMessageTest(String userKey) {
+        User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
+        FCMToken token = fcmTokenRepository.findByUser(user).orElseThrow();
+
+        String title = "Test Title";
+        String message = "Test Message, User : " + user.getName();
+        sendMessage(token.getToken(), title, message);
+    }
     @Transactional
     public List<String> getTokenNoExpenseToday() {
         return expenseRepository.findTokensWithoutExpenseToday();


### PR DESCRIPTION
## #45

## 📝작업 내용
- Firebase 계정이 donmani0104 에서 byeolbyeolso.official 로 변경됨에 따라 프로젝트 서비스 키 재발급
- 재발급 서비스 키에 대해서는 디스코드 서버 채팅 공유 
- 클라이언트단 푸시 이벤트 용이성을 위하여 테스트 API 개발 `send-messages/{userKey}`

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ebb09b37-ded3-4299-9deb-58f0586b2385)