### PR TITLE
[fix] key json encode&decode 방식으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,11 +43,11 @@ jobs:
           echo "${{ secrets.PROPERTIES_PROD }}" > ./application-prod.properties
         shell: bash
 
-      - name: Add FCM service account JSON key
+      - name: Decode and save Firebase service account JSON
         run: |
           cd ./src/main/resources
           touch ./bbsofficial-firebase-adminsdk.json
-          echo "${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}" > ./bbsofficial-firebase-adminsdk.json
+          echo "${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}" | base64 --decode > ./bbsofficial-firebase-adminsdk.json
 
       #test를 제외한 프로젝트 빌드
       - name: Build With Gradle


### PR DESCRIPTION
## #️⃣48

## 📝작업 내용

- key값의 쌍따옴표(`"`) 등 특수문자가 깨졌거나, Github Secret에서 줄바꿈을 인식하지 못해 json 포맷이 깨지는 현상
- key 값을 넣어줄 때 인코딩된 값을 넣어주고, copy 할 때 디코딩해주도록 변경