### PR TITLE
[refactor] 월별 요약에서 열린 달 기록없어도 0으로 내려주도록 변경 + 푸시 쿼리 수정

### DIFF
--- a/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
+++ b/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import donmani.donmani_server.expense.dto.*;
@@ -153,29 +154,19 @@ public class ExpenseService {
 				Collectors.counting()
 			));
 
-		// RecordInfoDTO 변환
-		Map<Integer, RecordInfoDTO> monthlyRecords = monthlyCounts.entrySet().stream()
-			.collect(Collectors.toMap(
-				Map.Entry::getKey, // 월(MonthValue)
-				entry -> new RecordInfoDTO(
-					entry.getValue(), // 해당 월의 기록이 있는 날짜 수
-					YearMonth.of(year, entry.getKey()).lengthOfMonth() // 해당 월의 총 날짜 수
-				)
-			));
+		// 현재 월 계산
+		int currentMonth = (year == LocalDate.now().getYear()) ? LocalDate.now().getMonthValue() : 12;
 
-		// Map<Integer, RecordInfoDTO> monthlyRecords = expenses.stream()
-		// 		.filter(exp -> exp.getCreatedAt().getYear() == year)
-		// 		.collect(Collectors.groupingBy(
-		// 				exp -> exp.getCreatedAt().getMonthValue(),
-		// 				Collectors.collectingAndThen(
-		// 						Collectors.toList(),
-		// 						list -> {
-		// 							long recordCount = list.size();
-		// 							int totalDaysInMonth = YearMonth.of(year, list.get(0).getCreatedAt().getMonthValue()).lengthOfMonth();
-		// 							return new RecordInfoDTO(recordCount, totalDaysInMonth);
-		// 						}
-		// 				)
-		// 		));
+		// RecordInfoDTO 변환 : 1월부터 현재 월까지 반복
+		Map<Integer, RecordInfoDTO> monthlyRecords = IntStream.rangeClosed(1, currentMonth)
+				.boxed()
+				.collect(Collectors.toMap(
+						month -> month,
+						month -> new RecordInfoDTO(
+								monthlyCounts.getOrDefault(month, 0L),
+								YearMonth.of(year, month).lengthOfMonth()
+						)
+				));
 
 		return ExpenseSummaryDTO.builder()
 				.year(year)

--- a/src/main/java/donmani/donmani_server/fcm/reposiory/PushExpenseRepository.java
+++ b/src/main/java/donmani/donmani_server/fcm/reposiory/PushExpenseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PushExpenseRepository extends JpaRepository<Expense, Long> {
@@ -16,7 +17,7 @@ public interface PushExpenseRepository extends JpaRepository<Expense, Long> {
     // 어제 소비 기록이 없는 유저의 FCM 토큰 조회
     @Query("SELECT f.token FROM FCMToken f WHERE NOT EXISTS " +
             "(SELECT e FROM Expense e WHERE e.userId = f.user.id " +
-            "AND e.createdAt >= FUNCTION('DATE_SUB', CURRENT_DATE, 1))")
-    List<String> findTokensWithoutExpenseYesterday();
+            "AND e.createdAt >= :yesterday)")
+    List<String> findTokensWithoutExpenseSince(@Param("yesterday") LocalDateTime yesterday);
 
 }

--- a/src/main/java/donmani/donmani_server/fcm/service/FCMService.java
+++ b/src/main/java/donmani/donmani_server/fcm/service/FCMService.java
@@ -1,8 +1,6 @@
 package donmani.donmani_server.fcm.service;
 
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseToken;
+
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -16,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.FileInputStream;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -81,7 +79,7 @@ public class FCMService {
 
     @Transactional
     public List<String> getTokenNoExpenseYesterday() {
-        return expenseRepository.findTokensWithoutExpenseYesterday();
+        return expenseRepository.findTokensWithoutExpenseSince(LocalDateTime.now().minusDays(1));
     }
 
 }


### PR DESCRIPTION
## #️⃣48

## 📝작업 내용

### 월 요약 기능에서 앱단과 협의된 내용으로 로직을 일부 수정함.
- 열린 달에 대해서 기록이 없어도 0으로 카운트를 내려주도록 수정
- 잠긴 달은 내려주지 않음. (기존 로직 유지)

### 푸시 메시지 에러 
- JPQL 날짜 계산 로직이 잘못되어 파라미터 방식으로 수정