### PR TITLE
[fix] 날짜 확인 조건 오류 수정

### DIFF
--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -42,8 +42,8 @@ public class RewardService {
         ZonedDateTime nowInSeoul = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
         LocalDate todayInSeoul = nowInSeoul.toLocalDate();
 
-        if(reqDate.getYear() == todayInSeoul.getYear() &&
-                reqDate.getMonthValue() == todayInSeoul.getMonthValue()) {
+        if(reqDate.getYear() != todayInSeoul.getYear() ||
+                reqDate.getMonthValue() != todayInSeoul.getMonthValue()) {
             // 어제 기록이 지난달이면 선물 받으면 안됨.
             return;
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81

## 📝작업 내용
- as-is : 요청 날짜가 오늘 날짜 기준의 **연/월이면** 선물이 안받아짐
- to-be : 요청 날짜가 오늘 날짜 기준의 **연/월이 아니면** 선물이 안받아짐