### PR TITLE
[hotfix] 장착한 아이템 쿼리 조회

### DIFF
--- a/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
@@ -12,11 +12,13 @@ public interface UserEquippedItemRepository extends JpaRepository<UserEquippedIt
     @Query("SELECT e FROM UserEquippedItem e " +
             "WHERE e.user = :user " +
             "AND FUNCTION('YEAR', e.savedAt) = :year " +
-            "AND FUNCTION('MONTH', e.savedAt) = :month")
-    Optional<UserEquippedItem> findByUserAndSavedAtInCurrentMonth(
+            "AND FUNCTION('MONTH', e.savedAt) = :month " +
+            "ORDER BY e.savedAt DESC")
+    Optional<UserEquippedItem> findTopByUserAndSavedAtInCurrentMonth(
             @Param("user") User user,
             @Param("year") int year,
             @Param("month") int month
     );
+
 
 }

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -230,7 +230,7 @@ public class RewardService {
             throw new IllegalArgumentException("유효하지 않은 요청입니다.");
         }
 
-        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findByUserAndSavedAtInCurrentMonth(user, year, month);
+        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user, year, month);
 
         RewardItem updateBackground = rewardItemRepository.findById(request.getBackgroundId()).orElseThrow();
         RewardItem updateEffect = rewardItemRepository.findById(request.getEffectId()).orElseThrow();
@@ -270,7 +270,7 @@ public class RewardService {
 
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findByUserAndSavedAtInCurrentMonth(user, year, month);
+        Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user, year, month);
 
         if(savedItem.isPresent()) {
             UserEquippedItem presentSavedItem = savedItem.get();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81

## 📝작업 내용

> 기존 쿼리가 장착했던 아이템 내역을 전부 조회하고 있는 쿼리여서 문제 발생
이를 해결하기 위하여, 최신 장착된 아이템 1개를 가져오는 쿼리로 수정 (top1 및 savedAt 기준 정렬 적용)