### PR TITLE
reward 기능 내 에러 사항 수정

### DIFF
--- a/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
+++ b/src/main/java/donmani/donmani_server/expense/service/ExpenseService.java
@@ -99,6 +99,7 @@ public class ExpenseService {
 			return ExpenseResponseDTO.builder()
 					.userKey(userKey)
 					.records(null)
+					.saveItems(rewardService.getSavedItem(userKey, year, month))
 					.hasNotOpenedRewards(hasNotOpenedRewards)
 					.build();
 		}

--- a/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
+++ b/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
@@ -2,6 +2,7 @@ package donmani.donmani_server.reward.dto;
 
 import donmani.donmani_server.reward.entity.RewardCategory;
 import donmani.donmani_server.reward.entity.RewardItem;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
@@ -10,11 +11,17 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class RewardItemResponseDTO {
+    @Schema(description = "리워드 아이템 id", example = "1")
     private Long id;
+
+    @Schema(description = "리워드 아이템 이름", example = "하트 잔잔")
     private String name;
+
+    @Schema(description = "리워드 아이템 이미지/gif URL", example = "하트 잔잔")
     private String imageUrl;
     private String jsonUrl;
     private String mp3Url;
+    private String thumbnailUrl;
     private RewardCategory category;
     private boolean isHidden;
     private boolean newAcquiredFlag;
@@ -35,6 +42,9 @@ public class RewardItemResponseDTO {
         );
         response.setMp3Url(
                 rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
+        );
+        response.setThumbnailUrl(
+                rewardItem.getThumbnailUrl() != null ? prefix + rewardItem.getThumbnailUrl() : null
         );
         response.setCategory(rewardItem.getCategory());
         response.setHidden(rewardItem.isHidden());
@@ -57,6 +67,9 @@ public class RewardItemResponseDTO {
         );
         response.setMp3Url(
                 rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
+        );
+        response.setThumbnailUrl(
+                rewardItem.getThumbnailUrl() != null ? prefix + rewardItem.getThumbnailUrl() : null
         );
         response.setCategory(rewardItem.getCategory());
         response.setHidden(rewardItem.isHidden());

--- a/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
+++ b/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
@@ -16,7 +16,7 @@ public class RewardItemResponseDTO {
     private String jsonUrl;
     private String mp3Url;
     private RewardCategory category;
-    private boolean owned;
+    private boolean isHidden;
     private boolean newAcquiredFlag;
 
     // 가지고 있는 아이템들만 보여줄 때 사용
@@ -37,12 +37,12 @@ public class RewardItemResponseDTO {
                 rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
         );
         response.setCategory(rewardItem.getCategory());
-        response.setOwned(true);
+        response.setHidden(rewardItem.isHidden());
 
         return response;
     }
 
-    public static RewardItemResponseDTO of(RewardItem rewardItem, boolean owned, boolean newAcquiredFlag) {
+    public static RewardItemResponseDTO of(RewardItem rewardItem, boolean newAcquiredFlag) {
         RewardItemResponseDTO response = new RewardItemResponseDTO();
 
         String prefix = "https://kr.object.ncloudstorage.com/donmani.bucket/reward_content/";
@@ -59,7 +59,7 @@ public class RewardItemResponseDTO {
                 rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
         );
         response.setCategory(rewardItem.getCategory());
-        response.setOwned(owned);
+        response.setHidden(rewardItem.isHidden());
         response.setNewAcquiredFlag(newAcquiredFlag);
 
         return response;

--- a/src/main/java/donmani/donmani_server/reward/entity/RewardItem.java
+++ b/src/main/java/donmani/donmani_server/reward/entity/RewardItem.java
@@ -29,5 +29,8 @@ public class RewardItem {
     @Column
     private String mp3Url;
 
+    @Column
+    private String thumbnailUrl;
+
     private boolean isHidden; // 히든 아이템 여부
 }

--- a/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
@@ -9,13 +9,14 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UserEquippedItemRepository extends JpaRepository<UserEquippedItem, Long> {
-    @Query("SELECT e FROM UserEquippedItem e " +
-            "WHERE e.user = :user " +
-            "AND FUNCTION('YEAR', e.savedAt) = :year " +
-            "AND FUNCTION('MONTH', e.savedAt) = :month " +
-            "ORDER BY e.savedAt DESC")
+    @Query(value = "SELECT * FROM user_equipped_item e " +
+            "WHERE e.user_id = :userId " +
+            "AND YEAR(e.saved_at) = :year " +
+            "AND MONTH(e.saved_at) = :month " +
+            "ORDER BY e.saved_at DESC " +
+            "LIMIT 1", nativeQuery = true)
     Optional<UserEquippedItem> findTopByUserAndSavedAtInCurrentMonth(
-            @Param("user") User user,
+            @Param("userId") Long userId,
             @Param("year") int year,
             @Param("month") int month
     );

--- a/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
@@ -14,8 +14,9 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
 
     @Query("SELECT ui FROM UserItem ui " +
             "WHERE ui.user = :user " +
-            "AND ui.acquiredAt BETWEEN :start AND :end")
-    List<UserItem> findByUserAndAcquiredAtBetween(
+            "AND ui.acquiredAt BETWEEN :start AND :end " +
+            "ORDER BY ui.acquiredAt DESC")
+    List<UserItem> findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(
             @Param("user") User user,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -251,7 +251,7 @@ public class RewardService {
 
         Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
 
-        if(!savedItem.isEmpty()) {
+        if(savedItem.isPresent()) {
             UserEquippedItem presentSavedItem = savedItem.get();
 
             background = presentSavedItem.getBackground();
@@ -278,13 +278,14 @@ public class RewardService {
                     .savedAt(LocalDateTime.now())
                     .build();
 
+            userEquippedItemRepository.save(newEquippedItem);
+
             // default 아이템도 userItem에 추가
             userItemRepository.save(makeUserItem(user, background));
             userItemRepository.save(makeUserItem(user, effect));
             userItemRepository.save(makeUserItem(user, decoration));
             userItemRepository.save(makeUserItem(user, byeoltongCase));
             userItemRepository.save(makeUserItem(user, bgm));
-            userEquippedItemRepository.save(newEquippedItem);
         }
 
         savedItems.add(RewardItemResponseDTO.of(background));

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -251,7 +251,7 @@ public class RewardService {
 
         Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user, year, month);
 
-        if(savedItem.isPresent()) {
+        if(!savedItem.isEmpty()) {
             UserEquippedItem presentSavedItem = savedItem.get();
 
             background = presentSavedItem.getBackground();

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -209,7 +209,7 @@ public class RewardService {
             throw new IllegalArgumentException("유효하지 않은 요청입니다.");
         }
 
-        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user, year, month);
+        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
 
         RewardItem updateBackground = rewardItemRepository.findById(request.getBackgroundId()).orElseThrow();
         RewardItem updateEffect = rewardItemRepository.findById(request.getEffectId()).orElseThrow();
@@ -249,7 +249,7 @@ public class RewardService {
 
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user, year, month);
+        Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
 
         if(!savedItem.isEmpty()) {
             UserEquippedItem presentSavedItem = savedItem.get();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81 

## 📝작업 내용
- thumbnailUrl 필드 추가
  - 배포 이후 thumbnail_url 데이터 필드 값 수정 필요 (DB) 
-  꾸미기 탭 진입 시(/reward/edit) 수정
  - 미사용 owned 필드 삭제
  - isHidden 필드 추가(히든 아이템일 때 true)
  - 획득한 아이템에 대해서 최신순 정렬
- 기록 조회 시, 기록이 없는 케이스에서 꾸미기 아이템 response 누락 수정
- userEquippedItem이 여러개 일때 최신 기록을 불러오도록 수정


## 추가 사항
**- 꾸미기 아이템 저장 시, 여러개의 데이터가 저장되거나 userItem이 중복으로 저장되는 이슈 해결해야 함.** 
=> 우선 예상되는 원인은 네트워크 등 알 수 없는 원인으로 userEquippedItem에 대한 최초 요청으로 동시 요청이 들어왔을 때, `userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth`의 결과가 잡히지 않고 중복 데이터가 들어오게 됨.. 
- locks 맵에 userKey별로 락 오브젝트를 만들어 동시성 제어
- 여러 사용자 요청 동시 처리 가능, 각 사용자는 별도 락으로 보호



