### PR TITLE
Hotfix 81

### DIFF
--- a/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
+++ b/src/main/java/donmani/donmani_server/reward/dto/RewardItemResponseDTO.java
@@ -20,7 +20,7 @@ public class RewardItemResponseDTO {
     @Schema(description = "리워드 아이템 이미지/gif URL", example = "하트 잔잔")
     private String imageUrl;
     private String jsonUrl;
-    private String mp3Url;
+    //private String mp3Url;
     private String thumbnailUrl;
     private RewardCategory category;
     private boolean isHidden;
@@ -40,9 +40,9 @@ public class RewardItemResponseDTO {
         response.setJsonUrl(
                 rewardItem.getJsonUrl() != null ? prefix + rewardItem.getJsonUrl() : null
         );
-        response.setMp3Url(
-                rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
-        );
+//        response.setMp3Url(
+//                rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
+//        );
         response.setThumbnailUrl(
                 rewardItem.getThumbnailUrl() != null ? prefix + rewardItem.getThumbnailUrl() : null
         );
@@ -65,9 +65,9 @@ public class RewardItemResponseDTO {
         response.setJsonUrl(
                 rewardItem.getJsonUrl() != null ? prefix + rewardItem.getJsonUrl() : null
         );
-        response.setMp3Url(
-                rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
-        );
+//        response.setMp3Url(
+//                rewardItem.getMp3Url() != null ? prefix + rewardItem.getMp3Url() : null
+//        );
         response.setThumbnailUrl(
                 rewardItem.getThumbnailUrl() != null ? prefix + rewardItem.getThumbnailUrl() : null
         );

--- a/src/main/java/donmani/donmani_server/reward/dto/RewardItemSaveRequestDTO.java
+++ b/src/main/java/donmani/donmani_server/reward/dto/RewardItemSaveRequestDTO.java
@@ -17,5 +17,5 @@ public class RewardItemSaveRequestDTO {
     private Long effectId;
     private Long decorationId;
     private Long byeoltongCaseId;
-    private Long bgmId;
+    //private Long bgmId;
 }

--- a/src/main/java/donmani/donmani_server/reward/entity/RewardCategory.java
+++ b/src/main/java/donmani/donmani_server/reward/entity/RewardCategory.java
@@ -5,7 +5,7 @@ public enum RewardCategory {
     EFFECT("효과"),
     DECORATION("장식"),
     CASE("별통이"),
-    BGM("배경음악"),
+    //BGM("배경음악"),
     ;
 
     private String name;

--- a/src/main/java/donmani/donmani_server/reward/entity/RewardItem.java
+++ b/src/main/java/donmani/donmani_server/reward/entity/RewardItem.java
@@ -26,8 +26,8 @@ public class RewardItem {
     @Column
     private String jsonUrl;
 
-    @Column
-    private String mp3Url;
+//    @Column
+//    private String mp3Url;
 
     @Column
     private String thumbnailUrl;

--- a/src/main/java/donmani/donmani_server/reward/entity/UserEquippedItem.java
+++ b/src/main/java/donmani/donmani_server/reward/entity/UserEquippedItem.java
@@ -33,18 +33,18 @@ public class UserEquippedItem {
     @ManyToOne
     private RewardItem byeoltongCase;
 
-    @ManyToOne
-    private RewardItem bgm;
+//    @ManyToOne
+//    private RewardItem bgm;
 
     private LocalDateTime savedAt;
 
     public void updateEquippedStatus(RewardItem background, RewardItem effect, RewardItem decoration,
-            RewardItem byeoltongCase, RewardItem bgm, LocalDateTime savedAt) {
+            RewardItem byeoltongCase, LocalDateTime savedAt) {
         this.background = background;
         this.effect = effect;
         this.decoration = decoration;
         this.byeoltongCase = byeoltongCase;
-        this.bgm = bgm;
+        //this.bgm = bgm;
         this.savedAt = savedAt;
     }
 }

--- a/src/main/java/donmani/donmani_server/reward/repository/RewardItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/RewardItemRepository.java
@@ -11,6 +11,6 @@ public interface RewardItemRepository extends JpaRepository<RewardItem, Long> {
     @Query("SELECT r FROM RewardItem r WHERE r.isHidden = true ORDER BY r.id ASC")
     Optional<RewardItem> findFirstByHiddenTrue();
 
-    @Query("SELECT r FROM RewardItem r WHERE r.isHidden = false")
-    List<RewardItem> findAllVisibleItems();
+    @Query("SELECT r FROM RewardItem r WHERE r.isHidden = false AND r.id NOT IN (1, 2, 3, 4)")
+    List<RewardItem> findAllVisibleItemsExcludingDefaults();
 }

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -234,56 +234,54 @@ public class RewardService {
 
         Object userLock = locks.computeIfAbsent(userKey, k -> new Object());
 
-        synchronized(userLock) {
-            User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
+        User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-            Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
+        Optional<UserEquippedItem> savedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
 
-            if(savedItem.isPresent()) {
-                UserEquippedItem presentSavedItem = savedItem.get();
+        if(savedItem.isPresent()) {
+            UserEquippedItem presentSavedItem = savedItem.get();
 
-                background = presentSavedItem.getBackground();
-                effect = presentSavedItem.getEffect();
-                decoration = presentSavedItem.getDecoration();
-                byeoltongCase = presentSavedItem.getByeoltongCase();
-                bgm = presentSavedItem.getBgm();
-            } else {
-                // 꾸미기 저장 데이터 없으면 default 세팅
-                background = rewardItemRepository.findById(1L).orElseThrow();
-                effect = rewardItemRepository.findById(2L).orElseThrow();
-                decoration = rewardItemRepository.findById(3L).orElseThrow();
-                byeoltongCase = rewardItemRepository.findById(4L).orElseThrow();
-                bgm = rewardItemRepository.findById(5L).orElseThrow();
+            background = presentSavedItem.getBackground();
+            effect = presentSavedItem.getEffect();
+            decoration = presentSavedItem.getDecoration();
+            byeoltongCase = presentSavedItem.getByeoltongCase();
+            bgm = presentSavedItem.getBgm();
+        } else {
+            // 꾸미기 저장 데이터 없으면 default 세팅
+            background = rewardItemRepository.findById(1L).orElseThrow();
+            effect = rewardItemRepository.findById(2L).orElseThrow();
+            decoration = rewardItemRepository.findById(3L).orElseThrow();
+            byeoltongCase = rewardItemRepository.findById(4L).orElseThrow();
+            bgm = rewardItemRepository.findById(5L).orElseThrow();
 
-                // default 세팅으로 저장
-                UserEquippedItem newEquippedItem = UserEquippedItem.builder()
-                        .user(user)
-                        .background(background)
-                        .effect(effect)
-                        .decoration(decoration)
-                        .byeoltongCase(byeoltongCase)
-                        .bgm(bgm)
-                        .savedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
-                        .build();
+            // default 세팅으로 저장
+            UserEquippedItem newEquippedItem = UserEquippedItem.builder()
+                    .user(user)
+                    .background(background)
+                    .effect(effect)
+                    .decoration(decoration)
+                    .byeoltongCase(byeoltongCase)
+                    .bgm(bgm)
+                    .savedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                    .build();
 
-                userEquippedItemRepository.save(newEquippedItem);
+            userEquippedItemRepository.save(newEquippedItem);
 
-                // default 아이템도 userItem에 추가
-                userItemRepository.save(makeUserItem(user, background));
-                userItemRepository.save(makeUserItem(user, effect));
-                userItemRepository.save(makeUserItem(user, decoration));
-                userItemRepository.save(makeUserItem(user, byeoltongCase));
-                userItemRepository.save(makeUserItem(user, bgm));
-            }
-
-            savedItems.add(RewardItemResponseDTO.of(background));
-            savedItems.add(RewardItemResponseDTO.of(effect));
-            savedItems.add(RewardItemResponseDTO.of(decoration));
-            savedItems.add(RewardItemResponseDTO.of(byeoltongCase));
-            savedItems.add(RewardItemResponseDTO.of(bgm));
-
-            return savedItems;
+            // default 아이템도 userItem에 추가
+            userItemRepository.save(makeUserItem(user, background));
+            userItemRepository.save(makeUserItem(user, effect));
+            userItemRepository.save(makeUserItem(user, decoration));
+            userItemRepository.save(makeUserItem(user, byeoltongCase));
+            userItemRepository.save(makeUserItem(user, bgm));
         }
+
+        savedItems.add(RewardItemResponseDTO.of(background));
+        savedItems.add(RewardItemResponseDTO.of(effect));
+        savedItems.add(RewardItemResponseDTO.of(decoration));
+        savedItems.add(RewardItemResponseDTO.of(byeoltongCase));
+        savedItems.add(RewardItemResponseDTO.of(bgm));
+
+        return savedItems;
     }
 
     private UserItem makeUserItem(User user, RewardItem item) {

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -212,34 +212,16 @@ public class RewardService {
             throw new IllegalArgumentException("유효하지 않은 요청입니다.");
         }
 
-        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
-
         RewardItem updateBackground = rewardItemRepository.findById(request.getBackgroundId()).orElseThrow();
         RewardItem updateEffect = rewardItemRepository.findById(request.getEffectId()).orElseThrow();
         RewardItem updateDecoration = rewardItemRepository.findById(request.getDecorationId()).orElseThrow();
         RewardItem updateByeoltongCase = rewardItemRepository.findById(request.getByeoltongCaseId()).orElseThrow();
         RewardItem updateBgm = rewardItemRepository.findById(request.getBgmId()).orElseThrow();
 
-        if(equippedItem.isPresent()) {
-            UserEquippedItem presentEquippedItem = equippedItem.get();
-            presentEquippedItem.updateEquippedStatus(updateBackground, updateEffect, updateDecoration, updateByeoltongCase, updateBgm, now);
+        UserEquippedItem presentEquippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month).orElseThrow();
+        presentEquippedItem.updateEquippedStatus(updateBackground, updateEffect, updateDecoration, updateByeoltongCase, updateBgm, now);
 
-            userEquippedItemRepository.save(presentEquippedItem);
-        }
-        else {
-            UserEquippedItem newEquippedItem = UserEquippedItem.builder()
-                    .user(user)
-                    .background(updateBackground)
-                    .effect(updateEffect)
-                    .decoration(updateDecoration)
-                    .byeoltongCase(updateByeoltongCase)
-                    .bgm(updateBgm)
-                    .savedAt(now)
-                    .build();
-
-            userEquippedItemRepository.save(newEquippedItem);
-        }
-
+        userEquippedItemRepository.save(presentEquippedItem);
     }
 
     /**

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -31,7 +31,7 @@ public class RewardService {
     private final FeedbackRepository feedbackRepository;
     private final UserEquippedItemRepository userEquippedItemRepository;
 
-    private final static int MAX_REWARD = 16; // default item 4개는 카운트에 불포함
+    private final static int MAX_REWARD = 12;
 
     /**
      * 기록과 동시에 선물 획득
@@ -54,17 +54,20 @@ public class RewardService {
         LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
 
         List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
+        Set<Long> acquiredItemIds = acquiredItems.stream()
+                .map(userItem -> userItem.getItem().getId())
+                .collect(Collectors.toSet());
 
         if(acquiredItems.size() == MAX_REWARD) {
             // 인당 월 최대 12개의 선물 생성 가능
-            // throw new IllegalStateException("이번 달 받을 수 있는 선물 개수를 초과하였습니다.");
             return;
         }
 
-        // user가 가지고 있지 않은 아이템 중 랜덤으로 획득 (히든 제외)
-        List<RewardItem> allItems = rewardItemRepository.findAllVisibleItems();
+        // user가 가지고 있지 않은 아이템 중 랜덤으로 획득 (히든, 디폴트 제외)
+        List<RewardItem> allItems = rewardItemRepository.findAllVisibleItemsExcludingDefaults();
+
         List<RewardItem> availableRewards = allItems.stream()
-                .filter(item -> !acquiredItems.contains(item))
+                .filter(item -> !acquiredItemIds.contains(item.getId()))
                 .collect(Collectors.toList());
 
         RewardItem selected = availableRewards.get(new Random().nextInt(availableRewards.size()));
@@ -153,26 +156,41 @@ public class RewardService {
      */
     @Transactional(readOnly = true)
     public Map<RewardCategory, List<RewardItemResponseDTO>> getAcquiredItem(String userKey) {
-        User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
+        User user = userRepository.findByUserKey(userKey)
+                .orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
-        LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime startOfMonth = YearMonth.now(zoneId).atDay(1).atStartOfDay();
+        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
+        LocalDateTime threeDaysAgo = LocalDateTime.now(zoneId).minusDays(3);
 
-        // 유저가 획득한 아이템
-        List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
-        LocalDateTime threeDaysAgo = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(3);
+        // 유저가 해당 월 획득한 아이템
+        List<UserItem> acquiredItems = userItemRepository
+                .findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, startOfMonth, endOfMonth);
 
-        List<RewardItemResponseDTO> response = acquiredItems.stream()
+        // 기본 아이템 ID 목록
+        List<Long> defaultItemIds = List.of(1L, 2L, 3L, 4L);
+
+        // 기본 아이템들을 DTO로 변환
+        List<RewardItemResponseDTO> response = defaultItemIds.stream()
+                .map(id -> rewardItemRepository.findById(id)
+                        .map(item -> RewardItemResponseDTO.of(item, false))
+                        .orElseThrow(() -> new RuntimeException("Default item ID " + id + " not found")))
+                .collect(Collectors.toList());
+
+        response.addAll(
+                acquiredItems.stream()
                 .map(item -> {
                     // 3일 이내 획득한 Item
-                    boolean newAcquired = item.getAcquiredAt().isAfter(threeDaysAgo) ? true : false;
+                    boolean newAcquired = item.getAcquiredAt().isAfter(threeDaysAgo);
                     // Hidden 아이템 처음 받았는지 여부
                     if(item.getItem().isHidden() && !item.isOpened()) {
                         newAcquired = true;
                     }
 
                     return RewardItemResponseDTO.of(item.getItem(), newAcquired);
-                }).collect(Collectors.toList());
+                }).collect(Collectors.toList())
+        );
 
         return response.stream()
                 .collect(Collectors.groupingBy(RewardItemResponseDTO::getCategory));
@@ -242,32 +260,12 @@ public class RewardService {
             byeoltongCase = presentSavedItem.getByeoltongCase();
             // bgm = presentSavedItem.getBgm();
         } else {
-            // 꾸미기 저장 데이터 없으면 default 세팅
+            // 꾸미기 저장 데이터 없으면 default
             background = rewardItemRepository.findById(1L).orElseThrow();
             effect = rewardItemRepository.findById(2L).orElseThrow();
             decoration = rewardItemRepository.findById(3L).orElseThrow();
             byeoltongCase = rewardItemRepository.findById(4L).orElseThrow();
             // bgm = rewardItemRepository.findById(5L).orElseThrow();
-
-            // default 세팅으로 저장
-            UserEquippedItem newEquippedItem = UserEquippedItem.builder()
-                    .user(user)
-                    .background(background)
-                    .effect(effect)
-                    .decoration(decoration)
-                    .byeoltongCase(byeoltongCase)
-                    //.bgm(bgm)
-                    .savedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
-                    .build();
-
-            userEquippedItemRepository.save(newEquippedItem);
-
-            // default 아이템도 userItem에 추가
-            userItemRepository.save(makeUserItem(user, background));
-            userItemRepository.save(makeUserItem(user, effect));
-            userItemRepository.save(makeUserItem(user, decoration));
-            userItemRepository.save(makeUserItem(user, byeoltongCase));
-            // userItemRepository.save(makeUserItem(user, bgm));
         }
 
         savedItems.add(RewardItemResponseDTO.of(background));
@@ -277,14 +275,6 @@ public class RewardService {
         // savedItems.add(RewardItemResponseDTO.of(bgm));
 
         return savedItems;
-    }
-
-    private UserItem makeUserItem(User user, RewardItem item) {
-        return UserItem.builder()
-                .user(user)
-                .item(item)
-                .acquiredAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
-                .isOpened(true).build();
     }
 
     /**


### PR DESCRIPTION
## 📝작업 내용

- 문제 : 별통이 기본 아이템이 2번 적용되는 오류 (동기/비동기 이슈인줄 알았으나 해당 조치 이후에도 동일 현상 발생)

- 별통이 꾸미기 불러오기 로직에만 default item init 되도록 수정
(기존 : 별통이 꾸미기 저장 시 저장된 아이템이 없다면 init 적용되어 중복 적용되었을 확률 있음.)
- bgm이 7월 중 오픈 일정으로 변경되며 관련 로직 삭제
- 싱크 동작 로직 삭제


---
### 추가 변경 사항 
- default 아이템은 매월, 모든 유저에게 공통 사항이므로 user_item 및 user_equipped_item 테이블에서 관리되지 않고 서비스 레이어에서만 분기 조건에 따라 조회되도록 수정
  - reward item 에서는 관리되고 있기 때문에 저장 및 조회 로직에서 특이사항 x
- 획득하지 않은 아이템 확인 로직에서 UserItem과 RewardItem이 동등 비교되는 오류 발견 -> id로 비교되도록 수정
