### PR TITLE
Reward 이슈 대응

### DIFF
--- a/src/main/java/donmani/donmani_server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/donmani/donmani_server/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package donmani.donmani_server.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(HiddenItemAlreadyOpenedException.class)
+    public ResponseEntity<Map<String, Object>> handleHiddenItemAlreadyOpened(HiddenItemAlreadyOpenedException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("error", "Bad Request");
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/donmani/donmani_server/common/exception/HiddenItemAlreadyOpenedException.java
+++ b/src/main/java/donmani/donmani_server/common/exception/HiddenItemAlreadyOpenedException.java
@@ -1,0 +1,11 @@
+package donmani.donmani_server.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class HiddenItemAlreadyOpenedException extends RuntimeException {
+    public HiddenItemAlreadyOpenedException() {
+        super("이미 히든 아이템을 열었습니다.");
+    }
+}

--- a/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
+++ b/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
@@ -1,14 +1,18 @@
 package donmani.donmani_server.feedback.service;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import donmani.donmani_server.expense.entity.CategoryType;
 import donmani.donmani_server.expense.repository.ExpenseRepository;
+import donmani.donmani_server.reward.entity.UserItem;
+import donmani.donmani_server.reward.repository.UserItemRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +36,7 @@ public class FeedbackService {
 	private final ExpenseRepository expenseRepository;
 	private final FeedbackRepository feedbackRepository;
 	private final FeedbackTemplateProvider feedbackTemplateProvider;
+	private final UserItemRepository userItemRepository;
 
 	@Transactional
 	public void addFeedback(ExpenseRequestDTO requestDTO) {
@@ -82,6 +87,17 @@ public class FeedbackService {
 			return false;
 		}
 
+		// 3. 이미 12개를 모두 열었다면 isNotOpened를 false로
+		LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
+		LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
+
+		List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
+
+		if(acquiredItems.size() == 12) {
+			return false;
+		}
+
+		// 4. 그 외는 true로 처리
 		return true;
 	}
 

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -1,5 +1,6 @@
 package donmani.donmani_server.reward.service;
 
+import donmani.donmani_server.common.exception.HiddenItemAlreadyOpenedException;
 import donmani.donmani_server.feedback.entity.Feedback;
 import donmani.donmani_server.feedback.repository.FeedbackRepository;
 import donmani.donmani_server.reward.dto.HiddenUpdateRequestDTO;
@@ -202,7 +203,8 @@ public class RewardService {
     public void updateHiddenRead(HiddenUpdateRequestDTO request) {
         User user = userRepository.findByUserKey(request.getUserKey()).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        UserItem findItem = userItemRepository.findOneUnopenedHiddenItem(user, request.getYear(), request.getMonth()).orElseThrow();
+        UserItem findItem = userItemRepository.findOneUnopenedHiddenItem(user, request.getYear(), request.getMonth())
+                .orElseThrow(HiddenItemAlreadyOpenedException::new);
 
         findItem.setOpened(true);
 

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -144,7 +144,7 @@ public class RewardService {
                     .user(user)
                     .item(hiddenItem)
                     .acquiredAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
-                    .isOpened(false)
+                    .isOpened(true)
                     .build();
             userItemRepository.save(newUserItem);
         }


### PR DESCRIPTION
## #96 

## 📝작업 내용

### 13번째 선물(MAX_SIZE 초과 케이스) 못 받게 수정
"13번째 기록 완료 후 홈 화면에 선물받기 툴팁 미노출 및 선물받기 안되어야 함."
- 해당 이슈 해결하기 위하여, 첫번째 커밋 메시지처럼 isOpened를 true로 히든 아이템이 받아지게 세팅하려고 했으나, 생각해보니 우리 로직해서는 해당 컬럼으로 히든 아이템 처음 받고 읽었을 때의 툴팁 출력 여부를 구별하고 있었음.
- 따라서 종식 오빠 요청대로, isNotOpened의 flag 값에 대하여 선물 12개 받았을 때는 false로 내려주게 해서 선물 열기에 대한 API 자체를 보내지 않도록 구성

### 이미 히든 아이템 열었는데 hidden read한 경우 예외 처리
- 히든 아이템을 이미 열었는데 또 열려고 하면 쿼리에서 500 에러가 떨어짐.
- 해당 에러 대응 및 앞으로의 모든 예외 케이스 동일을 위해 Exception Handler 코드 도입
- 예외 메시지 및 코드를 커스텀하고 적절하게 핸들링하기 위하여 전역적 핸들러 도입
- 타 API에 대해서도 동일 응답 구조로 형성하기 위해 리팩토링 필요함. @k906506 