### PR TITLE
[fix] 최초 장착의 경우 엔터티 생성으로 수정

### DIFF
--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -237,10 +237,23 @@ public class RewardService {
         RewardItem updateByeoltongCase = rewardItemRepository.findById(request.getByeoltongCaseId()).orElseThrow();
         // RewardItem updateBgm = rewardItemRepository.findById(request.getBgmId()).orElseThrow();
 
-        UserEquippedItem presentEquippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month).orElseThrow();
-        presentEquippedItem.updateEquippedStatus(updateBackground, updateEffect, updateDecoration, updateByeoltongCase, now);
+        Optional<UserEquippedItem> equippedItem = userEquippedItemRepository.findTopByUserAndSavedAtInCurrentMonth(user.getId(), year, month);
+        if(equippedItem.isPresent()) {
+            UserEquippedItem presentEquippedItem = equippedItem.get();
+            presentEquippedItem.updateEquippedStatus(updateBackground, updateEffect, updateDecoration, updateByeoltongCase, now);
+            userEquippedItemRepository.save(presentEquippedItem);
+        } else {
+            UserEquippedItem savedEquippedItem = UserEquippedItem.builder()
+                    .user(user)
+                    .savedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                    .background(updateBackground)
+                    .decoration(updateDecoration)
+                    .effect(updateEffect)
+                    .byeoltongCase(updateByeoltongCase)
+                    .build();
+            userEquippedItemRepository.save(savedEquippedItem);
+        }
 
-        userEquippedItemRepository.save(presentEquippedItem);
     }
 
     /**


### PR DESCRIPTION
## #️⃣96

## 📝작업 내용

- 꾸미기 아이템 최초 장착시 (해당 월에 장착한 데이터 없는 경우) -> UserEquippedItem 컬럼이 새로 생성되도록 수정
- 디비에 남아있던 이전 데이터들은 초기화를 안해주었어서 이슈 발견이 안되었던 것... 
