### PR TITLE
fix : 꾸미기 엣지 케이스 수정

### DIFF
--- a/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
@@ -27,7 +27,7 @@ public interface UserEquippedItemRepository extends JpaRepository<UserEquippedIt
             "AND e.saved_at < :beforeDate " +
             "ORDER BY e.saved_at DESC " +
             "LIMIT 1", nativeQuery = true)
-    Optional<UserEquippedItem> findTopBeforeDate(
+    Optional<UserEquippedItem> findLeastBeforeDate(
             @Param("userId") Long userId,
             @Param("beforeDate") LocalDateTime beforeDate
     );

--- a/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserEquippedItemRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserEquippedItemRepository extends JpaRepository<UserEquippedItem, Long> {
@@ -19,6 +20,16 @@ public interface UserEquippedItemRepository extends JpaRepository<UserEquippedIt
             @Param("userId") Long userId,
             @Param("year") int year,
             @Param("month") int month
+    );
+
+    @Query(value = "SELECT * FROM user_equipped_item e " +
+            "WHERE e.user_id = :userId " +
+            "AND e.saved_at < :beforeDate " +
+            "ORDER BY e.saved_at DESC " +
+            "LIMIT 1", nativeQuery = true)
+    Optional<UserEquippedItem> findTopBeforeDate(
+            @Param("userId") Long userId,
+            @Param("beforeDate") LocalDateTime beforeDate
     );
 
 

--- a/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
@@ -24,6 +24,14 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
 
     @Query("SELECT ui FROM UserItem ui " +
             "WHERE ui.user = :user " +
+            "ORDER BY ui.acquiredAt DESC")
+    List<UserItem> findByUserOrderByAcquiredAtDesc(
+            @Param("user") User user
+    );
+
+
+    @Query("SELECT ui FROM UserItem ui " +
+            "WHERE ui.user = :user " +
             "AND ui.acquiredAt BETWEEN :start AND :end " +
             "AND ui.isOpened = false")
     List<UserItem> findByUserAndAcquiredAtBetweenAndNotOpened(
@@ -31,6 +39,14 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Query("SELECT ui FROM UserItem ui " +
+            "WHERE ui.user = :user " +
+            "AND ui.isOpened = false")
+    List<UserItem> findByUserNotOpened(
+            @Param("user") User user
+    );
+
 
     @Query("SELECT ui FROM UserItem ui " +
             "JOIN ui.item i " +

--- a/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
@@ -29,17 +29,6 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
             @Param("user") User user
     );
 
-
-    @Query("SELECT ui FROM UserItem ui " +
-            "WHERE ui.user = :user " +
-            "AND ui.acquiredAt BETWEEN :start AND :end " +
-            "AND ui.isOpened = false")
-    List<UserItem> findByUserAndAcquiredAtBetweenAndNotOpened(
-            @Param("user") User user,
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end
-    );
-
     @Query("SELECT ui FROM UserItem ui " +
             "WHERE ui.user = :user " +
             "AND ui.isOpened = false")

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -40,27 +40,15 @@ public class RewardService {
      */
     @Transactional
     public void acquireRandomItems(String userKey, LocalDate reqDate) {
-        ZonedDateTime nowInSeoul = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-        LocalDate todayInSeoul = nowInSeoul.toLocalDate();
-
-        if(reqDate.getYear() != todayInSeoul.getYear() ||
-                reqDate.getMonthValue() != todayInSeoul.getMonthValue()) {
-            // 어제 기록이 지난달이면 선물 받으면 안됨.
-            return;
-        }
-
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
-        LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
-
-        List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
+        List<UserItem> acquiredItems = userItemRepository.findByUserNotOpened(user);
         Set<Long> acquiredItemIds = acquiredItems.stream()
                 .map(userItem -> userItem.getItem().getId())
                 .collect(Collectors.toSet());
 
         if(acquiredItems.size() == MAX_REWARD) {
-            // 인당 월 최대 12개의 선물 생성 가능
+            // 인당 최대 12개의 선물 생성 가능
             return;
         }
 
@@ -94,10 +82,7 @@ public class RewardService {
     public int getNotOpenedItemSize(String userKey) {
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
-        LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
-
-        List<UserItem> notOpenedItems = userItemRepository.findByUserAndAcquiredAtBetweenAndNotOpened(user, start, end);
+        List<UserItem> notOpenedItems = userItemRepository.findByUserNotOpened(user);
 
         return notOpenedItems.size();
     }
@@ -110,15 +95,12 @@ public class RewardService {
     public List<RewardItemResponseDTO> openItems(String userKey) {
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
-        LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
-
         // 피드백 열기 (중간 이탈해도 피드백+선물 한 set으로 열기)
         Feedback notOpenedFeedback = feedbackRepository.findFeedbackByIsOpenedOrderByCreatedDateDesc(user.getId()).get(0);
         notOpenedFeedback.setOpened(true);
 
         // 선물 열기
-        List<UserItem> notOpenedItems = userItemRepository.findByUserAndAcquiredAtBetweenAndNotOpened(user, start, end);
+        List<UserItem> notOpenedItems = userItemRepository.findByUserNotOpened(user);
         for (UserItem item : notOpenedItems) {
             item.setOpened(true);
         }
@@ -127,7 +109,7 @@ public class RewardService {
         userItemRepository.saveAll(notOpenedItems);
 
         // 히든 아이템 획득
-        acquireHiddenItems(user, start, end);;
+        acquireHiddenItems(user);;
 
         List<RewardItemResponseDTO> response = new ArrayList<>();
         for (UserItem item : notOpenedItems) {
@@ -137,8 +119,8 @@ public class RewardService {
         return response;
     }
 
-    private void acquireHiddenItems(User user, LocalDateTime start, LocalDateTime end) {
-        List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
+    private void acquireHiddenItems(User user) {
+        List<UserItem> acquiredItems = userItemRepository.findByUserOrderByAcquiredAtDesc(user);
         if(acquiredItems.size() == MAX_REWARD) {
             RewardItem hiddenItem = rewardItemRepository.findFirstByHiddenTrue().orElseThrow();
             UserItem newUserItem = UserItem.builder()
@@ -163,13 +145,10 @@ public class RewardService {
                 .orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
         ZoneId zoneId = ZoneId.of("Asia/Seoul");
-        LocalDateTime startOfMonth = YearMonth.now(zoneId).atDay(1).atStartOfDay();
-        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusNanos(1);
         LocalDateTime threeDaysAgo = LocalDateTime.now(zoneId).minusDays(3);
 
-        // 유저가 해당 월 획득한 아이템
-        List<UserItem> acquiredItems = userItemRepository
-                .findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, startOfMonth, endOfMonth);
+        // 유저가 획득한 아이템
+        List<UserItem> acquiredItems = userItemRepository.findByUserOrderByAcquiredAtDesc(user);
 
         // 기본 아이템 ID 목록
         List<Long> defaultItemIds = List.of(1L, 2L, 3L, 4L);

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -258,7 +258,7 @@ public class RewardService {
         } else {
             // 기준 날짜보다 이전 날짜 중 가장 최근에 저장된 꾸미기 상태 불러오기
             LocalDateTime beforeDate = LocalDateTime.of(year, month, 1, 0, 0);
-            Optional<UserEquippedItem> lastEquippedItem = userEquippedItemRepository.findTopBeforeDate(user.getId(), beforeDate);
+            Optional<UserEquippedItem> lastEquippedItem = userEquippedItemRepository.findLeastBeforeDate(user.getId(), beforeDate);
 
             // 있다면 불러오고 해당 상태로 해당 월에 저장
             if(lastEquippedItem.isPresent()) {


### PR DESCRIPTION
- 사용자가 획득한 아이템은 사라지지 않아야 함 (영구 보관)
- 새로운 달이 되어도 사용자가 이전에 꾸민 설정 그대로 유지 (매월 마지막일 23:59:59까지 세팅된 상태 픽스, 수정 가능한 상태)
  - **꾸미기 상태 불러오기에서 별도 꾸민 기록이 요청월에 없다면 해당 날짜 기준 이전 중 가장 최신 저장된 꾸미기 상태 불러옴.** 
- 이전 달은 “매월 마지막일 23:59:59” 세팅된 상태로 저장
- 다른 날과 동일하게 선물 받기/꾸미기 가능해야 함