### PR TITLE
[fix] 월 기준 선물 획득 로직 아예 삭제

### DIFF
--- a/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
+++ b/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
@@ -88,10 +88,7 @@ public class FeedbackService {
 		}
 
 		// 3. 이미 12개를 모두 열었다면 isNotOpened를 false로
-		LocalDateTime start = YearMonth.now(ZoneId.of("Asia/Seoul")).atDay(1).atStartOfDay();
-		LocalDateTime end = start.plusMonths(1).minusNanos(1); // 23:59:59.999999999
-
-		List<UserItem> acquiredItems = userItemRepository.findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(user, start, end);
+		List<UserItem> acquiredItems = userItemRepository.findAllByUser(user);
 
 		if(acquiredItems.size() == 12) {
 			return false;

--- a/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
@@ -11,17 +11,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserItemRepository extends JpaRepository<UserItem, Long> {
-
-    @Query("SELECT ui FROM UserItem ui " +
-            "WHERE ui.user = :user " +
-            "AND ui.acquiredAt BETWEEN :start AND :end " +
-            "ORDER BY ui.acquiredAt DESC")
-    List<UserItem> findByUserAndAcquiredAtBetweenOrderByAcquiredAtDesc(
-            @Param("user") User user,
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end
-    );
-
     @Query("SELECT ui FROM UserItem ui " +
             "WHERE ui.user = :user " +
             "ORDER BY ui.acquiredAt DESC")
@@ -36,6 +25,11 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long> {
             @Param("user") User user
     );
 
+    @Query("SELECT ui FROM UserItem ui " +
+            "WHERE ui.user = :user ")
+    List<UserItem> findAllByUser(
+            @Param("user") User user
+    );
 
     @Query("SELECT ui FROM UserItem ui " +
             "JOIN ui.item i " +

--- a/src/main/java/donmani/donmani_server/reward/service/RewardService.java
+++ b/src/main/java/donmani/donmani_server/reward/service/RewardService.java
@@ -42,7 +42,7 @@ public class RewardService {
     public void acquireRandomItems(String userKey, LocalDate reqDate) {
         User user = userRepository.findByUserKey(userKey).orElseThrow(() -> new RuntimeException("USER NOT FOUND"));
 
-        List<UserItem> acquiredItems = userItemRepository.findByUserNotOpened(user);
+        List<UserItem> acquiredItems = userItemRepository.findAllByUser(user);
         Set<Long> acquiredItemIds = acquiredItems.stream()
                 .map(userItem -> userItem.getItem().getId())
                 .collect(Collectors.toSet());
@@ -120,7 +120,7 @@ public class RewardService {
     }
 
     private void acquireHiddenItems(User user) {
-        List<UserItem> acquiredItems = userItemRepository.findByUserOrderByAcquiredAtDesc(user);
+        List<UserItem> acquiredItems = userItemRepository.findAllByUser(user);
         if(acquiredItems.size() == MAX_REWARD) {
             RewardItem hiddenItem = rewardItemRepository.findFirstByHiddenTrue().orElseThrow();
             UserItem newUserItem = UserItem.builder()
@@ -134,7 +134,7 @@ public class RewardService {
     }
 
     /**
-     * 꾸미기 탭 접속하여 아이템 리스트 조회 (해당월)
+     * 꾸미기 탭 접속하여 아이템 리스트 조회
      * 전체 아이템 및 획득 아이템 표시
      * @param userKey
      * @return


### PR DESCRIPTION
## #️⃣96

## 📝작업 내용
- 꾸미기 아이템 소장 기간에 대한 로직 수정 중 누락 사항 반영
1. 사용자가 가지고 있는 꾸미기 아이템 개수 확인 쿼리가 'notOpened' 기준으로 되어 있어 0개가 집계되는 이슈 -> findAllByUser 조건으로 수정
2. 피드백에서 NotOpen 조회 시 월별 기간으로 집계하고 있어 해당 부분에서 기간 삭제된 쿼리로 변경
