### PR TITLE
[hotfix] 아이템 조회 쿼리 오류 수정 (where 조건)

### DIFF
--- a/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
+++ b/src/main/java/donmani/donmani_server/feedback/service/FeedbackService.java
@@ -88,7 +88,7 @@ public class FeedbackService {
 		}
 
 		// 3. 이미 12개를 모두 열었다면 isNotOpened를 false로
-		List<UserItem> acquiredItems = userItemRepository.findAllByUser(user);
+		List<UserItem> acquiredItems = userItemRepository.findByUserOrderByAcquiredAtDesc(user);
 
 		if(acquiredItems.size() == 12) {
 			return false;

--- a/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
+++ b/src/main/java/donmani/donmani_server/reward/repository/UserItemRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface UserItemRepository extends JpaRepository<UserItem, Long> {
     @Query("SELECT ui FROM UserItem ui " +
             "WHERE ui.user = :user " +
+            "AND ui.isOpened = true " +
             "ORDER BY ui.acquiredAt DESC")
     List<UserItem> findByUserOrderByAcquiredAtDesc(
             @Param("user") User user


### PR DESCRIPTION
## 원인 파악 (백엔드)

1. 마지막 받은 아이템 not-open
    ![image](https://github.com/user-attachments/assets/a3d929d2-3e43-45b1-b11f-ee1507b13e5d)
    
2. not-open 선물 카운트
![image](https://github.com/user-attachments/assets/40c0de7a-6808-46d7-8b72-85abfdba8351)

## 해결
1. `/reward/edit/{userKey}` **결과 ⇒ 열지 않은 아이템도 모두 출력**
    
    **사용자의 아이템만 출력되도록 수정**
    
  ![image](https://github.com/user-attachments/assets/54c14890-5b14-4b82-ba98-448e37503315)
    
2. `/feedback/{userKey}` **결과 ⇒** 
    
![image](https://github.com/user-attachments/assets/77800e4c-8975-4d21-b90f-f2c526034f0f)
    
    **isNotOpened가 true로 보일 수 있도록 수정**
![image](https://github.com/user-attachments/assets/178a1e5d-3f7c-4853-8ed5-0a7731da8d81)
